### PR TITLE
Make arrow functions normal es5 funcs.

### DIFF
--- a/src/use-context.js
+++ b/src/use-context.js
@@ -1,4 +1,6 @@
 const React = require('react');
 const FluxibleContext = require('fluxible-context');
 
-module.exports = () => React.useContext(FluxibleContext);
+module.exports = function() {
+    return React.useContext(FluxibleContext);
+};

--- a/src/use-stores.js
+++ b/src/use-stores.js
@@ -2,27 +2,27 @@ const React = require('react');
 const useContext = require('./use-context');
 
 module.exports = function useStores(stores, getStateFromStores) {
-  const context = useContext();
-  const s = React.useState(getStateFromStores(context));
-  const state = s[0];
-  const setState = s[1];
-  function onChange() {
-    setState(getStateFromStores(context));
-  }
-  function subscribe() {
-    stores.forEach((Store) => {
-      context.getStore(Store).on('change', onChange);
+    const context = useContext();
+    const s = React.useState(getStateFromStores(context));
+    const state = s[0];
+    const setState = s[1];
+    function onChange() {
+        setState(getStateFromStores(context));
+    }
+    function subscribe() {
+        stores.forEach(function(Store) {
+            context.getStore(Store).on('change', onChange);
+        });
+    }
+    function unsubscribe() {
+        stores.forEach(function(Store) {
+            context.getStore(Store).removeListener('change', onChange);
+        });
+    }
+    React.useEffect(function() {
+        subscribe();
+        return unsubscribe;
     });
-  }
-  function unsubscribe() {
-    stores.forEach((Store) => {
-      context.getStore(Store).removeListener('change', onChange);
-    });
-  }
-  React.useEffect(() => {
-    subscribe();
-    return unsubscribe;
-  });
 
-  return state;
+    return state;
 };


### PR DESCRIPTION
This repo doesn't build into es5 and arrow functions will cause errors in older browsers (ex: ie11).